### PR TITLE
Added method to toggle expand state for a single row. Bug fix to changeE...

### DIFF
--- a/Classes/TSUIKit/TSTableView/TSTableView.h
+++ b/Classes/TSUIKit/TSTableView/TSTableView.h
@@ -181,6 +181,11 @@
 - (void)changeExpandStateForRow:(NSIndexPath *)rowPath toValue:(BOOL)expanded animated:(BOOL)animated;
 
 /**
+ @abstract Toggle expand state of the row
+ */
+- (void)toggleExpandStateForRow:(NSIndexPath *)rowPath animated:(BOOL)animated;
+
+/**
     @abstract Expand all rows
  */
 - (void)expandAllRowsWithAnimation:(BOOL)animated;

--- a/Classes/TSUIKit/TSTableView/TSTableView.m
+++ b/Classes/TSUIKit/TSTableView/TSTableView.m
@@ -423,9 +423,17 @@
 
 #pragma mark - 
 
+- (void)toggleExpandStateForRow:(NSIndexPath *)rowPath animated:(BOOL)animated
+{
+    VerboseLog();
+    BOOL expand = ![_tableControlPanel isRowExpanded:rowPath];
+    [self changeExpandStateForRow:rowPath toValue:expand animated:animated];
+}
+
 - (void)changeExpandStateForRow:(NSIndexPath *)rowPath toValue:(BOOL)expanded animated:(BOOL)animated
 {
     VerboseLog();
+    [_tableControlPanel changeExpandStateForRow:rowPath toValue:expanded animated:YES];
     [_tableContentHolder changeExpandStateForRow:rowPath toValue:expanded animated:YES];
     [self updateLayout];
 }


### PR DESCRIPTION
...xpandStateForRow method

I've modified changeExpandStateForRow:toValue:animated:
I think it was a bug not send message changeExpandStateForRow:toValue:animated:  to _tableControlPanel.

I've also added toggleExpandStateForRow:animated: to quickly switch every single row from expanded to collapsed state.
