### PR TITLE
Fixed Xcode6.3 warning

### DIFF
--- a/Classes/TSUIKit/TSTabViewWithDropDownPanel/TSTabViewWithDropDownPanel.m
+++ b/Classes/TSUIKit/TSTabViewWithDropDownPanel/TSTabViewWithDropDownPanel.m
@@ -50,6 +50,8 @@ typedef enum {
 
 @implementation TSTabViewWithDropDownPanel
 
+//@dynamic delegate;
+
 - (id)initWithFrame:(CGRect)rect navigationMenu:(TSNavigationStripView *)navigationMenu
 {
     VerboseLog();

--- a/Classes/TSUIKit/TSTabViewWithDropDownPanel/TSTabViewWithDropDownPanel.m
+++ b/Classes/TSUIKit/TSTabViewWithDropDownPanel/TSTabViewWithDropDownPanel.m
@@ -50,7 +50,7 @@ typedef enum {
 
 @implementation TSTabViewWithDropDownPanel
 
-//@dynamic delegate;
+@dynamic delegate;
 
 - (id)initWithFrame:(CGRect)rect navigationMenu:(TSNavigationStripView *)navigationMenu
 {


### PR DESCRIPTION
I fixed Xcode 6.3 warning on property delegate of TSTabViewWithDropDownPanel.
Property delegate is declared in TSTabView superclass of type id<TSTabViewDelegate>, while in TSTabViewWithDropDownPanel subclass is declared of type id<TSTabViewWithDropDownPanelDelegate>. To keep this working on Xcode 6.3 I added dynamic statement into TSTabViewWithDropDownPanel implementation.
